### PR TITLE
Add SEO basics for release

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://gtc.gtstor.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://gtc.gtstor.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,43 @@
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import '../styles/globals.css';
 
+const SITE_URL = 'https://gtc.gtstor.com';
+const TITLE = 'GTC — AI-платформа для осознанных покупок';
+const DESCRIPTION =
+  'GTC помогает бизнесу принимать взвешанные решения: AI-консультант, новости рынка и интеграция оплаты в одном месте.';
+const OG_IMAGE = `${SITE_URL}/fallback-hero.png`;
+
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Head>
+        <title>{TITLE}</title>
+        <meta name="description" content={DESCRIPTION} />
+        <meta
+          name="keywords"
+          content="GTC, AI-платформа, умные закупки, осознанные покупки, аналитика, новости рынка, GTStor"
+        />
+        <meta name="robots" content="index,follow" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#0b1220" />
+        <link rel="canonical" href={SITE_URL} />
+
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={SITE_URL} />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESCRIPTION} />
+        <meta property="og:image" content={OG_IMAGE} />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:url" content={SITE_URL} />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESCRIPTION} />
+        <meta name="twitter:image" content={OG_IMAGE} />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 }
 
 export default MyApp;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="ru">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
## Summary
- add default SEO metadata and social sharing tags to the global app layout
- expose html language attribute via a custom document
- add robots.txt and sitemap.xml to prepare for search engine indexing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce7215cefc832aa6e8c1469e419493