### PR TITLE
Add robots.txt and sitemap for production domain

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://gtstor.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://gtstor.com/</loc>
+    <lastmod>2025-09-20</lastmod>
+    <changefreq>weekly</changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add a robots.txt that allows crawling and points to the production sitemap URL
- add a sitemap.xml with the production homepage entry, lastmod, and change frequency metadata

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68ce8ec8f0ac832a9a3e6e5f6062047f