### PR TITLE
Add noopener to HeroOverlay external links

### DIFF
--- a/src/components/HeroOverlay.tsx
+++ b/src/components/HeroOverlay.tsx
@@ -30,13 +30,28 @@ export default function HeroOverlay() {
       <p style={sub}>Взвешанные решения: AI-консультант, новости, интеграция оплаты.</p>
 
       <div style={row}>
-        <a href="https://t.me/Procurement_AnalystBot" target="_blank" rel="noreferrer" style={btn('#67e8f9')}>
+        <a
+          href="https://t.me/Procurement_AnalystBot"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={btn('#67e8f9')}
+        >
           Открыть бота
         </a>
-        <a href="https://app.gtstor.com/news/" target="_blank" rel="noreferrer" style={btn('rgba(255,255,255,0.12)', '#fff')}>
+        <a
+          href="https://app.gtstor.com/news/"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={btn('rgba(255,255,255,0.12)', '#fff')}
+        >
           Читать новости
         </a>
-        <a href="https://pay.gtstor.com/payment.php" target="_blank" rel="noreferrer" style={btn('#34d399')}>
+        <a
+          href="https://pay.gtstor.com/payment.php"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={btn('#34d399')}
+        >
           Оформить доступ
         </a>
       </div>


### PR DESCRIPTION
## Summary
- ensure HeroOverlay external links include noopener alongside noreferrer when opening in a new tab

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce98951788832a9a45c776821e2991