### PR TITLE
Remove ts-nocheck and align R3F JSX typings

### DIFF
--- a/src/components/Hero3DCanvas.tsx
+++ b/src/components/Hero3DCanvas.tsx
@@ -1,18 +1,3 @@
-// @ts-nocheck
-/* Локальная декларация IntrinsicElements — чтобы Vercel TS не падал на R3F-тегах */
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      mesh: any;
-      sphereGeometry: any;
-      torusGeometry: any;
-      meshStandardMaterial: any;
-      ambientLight: any;
-      pointLight: any;
-    }
-  }
-}
-
 import * as React from 'react'
 import * as THREE from 'three'
 import { Canvas, useFrame } from '@react-three/fiber'

--- a/src/types/r3f-group-shim.d.ts
+++ b/src/types/r3f-group-shim.d.ts
@@ -1,8 +1,17 @@
+import type { ThreeElements } from '@react-three/fiber'
+
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      group: any;
+      group: ThreeElements['group']
+    }
+  }
+  namespace React {
+    namespace JSX {
+      interface IntrinsicElements {
+        group: ThreeElements['group']
+      }
     }
   }
 }
-export {};
+export {}

--- a/src/types/r3f-intrinsics.d.ts
+++ b/src/types/r3f-intrinsics.d.ts
@@ -1,18 +1,29 @@
-import '@react-three/fiber';
+import '@react-three/fiber'
+import type { ThreeElements } from '@react-three/fiber'
 
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      // геометрии/материалы/свет/меши, которые есть в нашем Hero3DCanvas
-      mesh: any;
-      sphereGeometry: any;
-      torusGeometry: any;
-      meshStandardMaterial: any;
-      ambientLight: any;
-      pointLight: any;
-      // если когда-то вернётся <group/>, он уже перекрыт в другом d.ts
+      mesh: ThreeElements['mesh']
+      sphereGeometry: ThreeElements['sphereGeometry']
+      torusGeometry: ThreeElements['torusGeometry']
+      meshStandardMaterial: ThreeElements['meshStandardMaterial']
+      ambientLight: ThreeElements['ambientLight']
+      pointLight: ThreeElements['pointLight']
+    }
+  }
+  namespace React {
+    namespace JSX {
+      interface IntrinsicElements {
+        mesh: ThreeElements['mesh']
+        sphereGeometry: ThreeElements['sphereGeometry']
+        torusGeometry: ThreeElements['torusGeometry']
+        meshStandardMaterial: ThreeElements['meshStandardMaterial']
+        ambientLight: ThreeElements['ambientLight']
+        pointLight: ThreeElements['pointLight']
+      }
     }
   }
 }
 
-export {};
+export {}

--- a/src/types/r3f-jsx.d.ts
+++ b/src/types/r3f-jsx.d.ts
@@ -1,11 +1,19 @@
-import '@react-three/fiber';
+import '@react-three/fiber'
+import type { ThreeElements } from '@react-three/fiber'
 
 // Локальная декларация на случай, если окружение не подхватило типы R3F
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      group: any;
+      group: ThreeElements['group']
+    }
+  }
+  namespace React {
+    namespace JSX {
+      interface IntrinsicElements {
+        group: ThreeElements['group']
+      }
     }
   }
 }
-export {};
+export {}


### PR DESCRIPTION
## Summary
- drop the local `@ts-nocheck` shim from `Hero3DCanvas` now that JSX tags are typed
- map the hero scene's mesh/material/light tags to `@react-three/fiber`'s `ThreeElements` for both `JSX` and `React.JSX`
- update the R3F group shims to reference `ThreeElements['group']` so React 19 picks up the correct JSX type

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ce98aaf578832a8dba1f5ede3480a8