### PR TITLE
Remove aria-live from hero overlay container

### DIFF
--- a/src/components/HeroOverlay.tsx
+++ b/src/components/HeroOverlay.tsx
@@ -25,7 +25,7 @@ export default function HeroOverlay() {
   });
 
   return (
-    <div style={wrap} aria-live="polite">
+    <div style={wrap}>
       <h1 style={h1}>AI-платформа для осознанных покупок</h1>
       <p style={sub}>Взвешанные решения: AI-консультант, новости, интеграция оплаты.</p>
 


### PR DESCRIPTION
## Summary
- remove the aria-live attribute from the hero overlay wrapper to avoid redundant announcements

## Testing
- npx @lhci/cli collect --url=http://localhost:3000 --settings.preset=desktop --settings.onlyCategories=accessibility *(fails: Chrome not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceab143a60832ab72afe025894b0c6