### PR TITLE
refactor: enable R3F typings for hero canvas

### DIFF
--- a/src/components/Hero3DCanvas.tsx
+++ b/src/components/Hero3DCanvas.tsx
@@ -1,44 +1,58 @@
-// @ts-nocheck
-/* Локальная декларация IntrinsicElements — чтобы Vercel TS не падал на R3F-тегах */
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      mesh: any;
-      sphereGeometry: any;
-      torusGeometry: any;
-      meshStandardMaterial: any;
-      ambientLight: any;
-      pointLight: any;
-    }
-  }
-}
-
 import * as React from 'react'
 import * as THREE from 'three'
 import { Canvas, useFrame } from '@react-three/fiber'
+import type { ThreeElements } from '@react-three/fiber'
+
+const LIGHT_FRONT_POSITION: ThreeElements['pointLight']['position'] = [6, 6, 6]
+const LIGHT_BACK_POSITION: ThreeElements['pointLight']['position'] = [-6, -6, -6]
+
+const SPHERE_ARGS: ThreeElements['sphereGeometry']['args'] = [1.6, 48, 48]
+
+const TORUS_ONE_ARGS: ThreeElements['torusGeometry']['args'] = [2.6, 0.02, 8, 128]
+const TORUS_TWO_ARGS: ThreeElements['torusGeometry']['args'] = [2.0, 0.02, 8, 128]
+const TORUS_THREE_ARGS: ThreeElements['torusGeometry']['args'] = [3.2, 0.02, 8, 128]
+
+const TORUS_ONE_ROTATION: ThreeElements['mesh']['rotation'] = [Math.PI / 2, 0, 0]
+const TORUS_TWO_ROTATION: ThreeElements['mesh']['rotation'] = [0, Math.PI / 2, 0]
+const TORUS_THREE_ROTATION: ThreeElements['mesh']['rotation'] = [0, 0, Math.PI / 2]
+
+const CANVAS_STYLE: React.CSSProperties = { background: '#0b1220' }
+const CANVAS_DPR: [number, number] = [1, 2]
+const CAMERA_SETTINGS = {
+  position: [0, 0, 8] as [number, number, number],
+  fov: 50,
+}
 
 function Scene() {
-  const sphereRef = React.useRef<THREE.Mesh>(null!)
-  const torus1Ref = React.useRef<THREE.Mesh>(null!)
-  const torus2Ref = React.useRef<THREE.Mesh>(null!)
-  const torus3Ref = React.useRef<THREE.Mesh>(null!)
+  const sphereRef = React.useRef<
+    THREE.Mesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>
+  >(null)
+  const torus1Ref = React.useRef<
+    THREE.Mesh<THREE.TorusGeometry, THREE.MeshStandardMaterial>
+  >(null)
+  const torus2Ref = React.useRef<
+    THREE.Mesh<THREE.TorusGeometry, THREE.MeshStandardMaterial>
+  >(null)
+  const torus3Ref = React.useRef<
+    THREE.Mesh<THREE.TorusGeometry, THREE.MeshStandardMaterial>
+  >(null)
 
-  useFrame((_, dt) => {
-    if (sphereRef.current) sphereRef.current.rotation.y += dt * 0.25
-    if (torus1Ref.current) torus1Ref.current.rotation.y += dt * 0.10
-    if (torus2Ref.current) torus2Ref.current.rotation.x += dt * 0.10
-    if (torus3Ref.current) torus3Ref.current.rotation.z += dt * 0.10
+  useFrame((_, delta) => {
+    if (sphereRef.current) sphereRef.current.rotation.y += delta * 0.25
+    if (torus1Ref.current) torus1Ref.current.rotation.y += delta * 0.1
+    if (torus2Ref.current) torus2Ref.current.rotation.x += delta * 0.1
+    if (torus3Ref.current) torus3Ref.current.rotation.z += delta * 0.1
   })
 
   return (
     <>
       <ambientLight intensity={0.6} />
-      <pointLight position={[6, 6, 6]} intensity={50} />
-      <pointLight position={[-6, -6, -6]} intensity={20} />
+      <pointLight position={LIGHT_FRONT_POSITION} intensity={50} />
+      <pointLight position={LIGHT_BACK_POSITION} intensity={20} />
 
       {/* Центральная сфера */}
       <mesh ref={sphereRef}>
-        <sphereGeometry args={[1.6, 48, 48]} />
+        <sphereGeometry args={SPHERE_ARGS} />
         <meshStandardMaterial
           color="#67e8f9"
           emissive="#22d3ee"
@@ -49,18 +63,18 @@ function Scene() {
       </mesh>
 
       {/* Три орбиты */}
-      <mesh ref={torus1Ref} rotation={[Math.PI / 2, 0, 0]}>
-        <torusGeometry args={[2.6, 0.02, 8, 128]} />
+      <mesh ref={torus1Ref} rotation={TORUS_ONE_ROTATION}>
+        <torusGeometry args={TORUS_ONE_ARGS} />
         <meshStandardMaterial color="#93c5fd" />
       </mesh>
 
-      <mesh ref={torus2Ref} rotation={[0, Math.PI / 2, 0]}>
-        <torusGeometry args={[2.0, 0.02, 8, 128]} />
+      <mesh ref={torus2Ref} rotation={TORUS_TWO_ROTATION}>
+        <torusGeometry args={TORUS_TWO_ARGS} />
         <meshStandardMaterial color="#a7f3d0" />
       </mesh>
 
-      <mesh ref={torus3Ref} rotation={[0, 0, Math.PI / 2]}>
-        <torusGeometry args={[3.2, 0.02, 8, 128]} />
+      <mesh ref={torus3Ref} rotation={TORUS_THREE_ROTATION}>
+        <torusGeometry args={TORUS_THREE_ARGS} />
         <meshStandardMaterial color="#fbcfe8" />
       </mesh>
     </>
@@ -70,10 +84,10 @@ function Scene() {
 export default function Hero3DCanvas() {
   return (
     <Canvas
-      camera={{ position: [0, 0, 8], fov: 50 }}
-      dpr={[1, 2]}
+      camera={CAMERA_SETTINGS}
+      dpr={CANVAS_DPR}
       gl={{ antialias: true }}
-      style={{ background: '#0b1220' }}
+      style={CANVAS_STYLE}
     >
       <Scene />
     </Canvas>

--- a/src/types/r3f-intrinsics.d.ts
+++ b/src/types/r3f-intrinsics.d.ts
@@ -1,18 +1,9 @@
-import '@react-three/fiber';
+import type { ThreeElements } from '@react-three/fiber'
 
 declare global {
   namespace JSX {
-    interface IntrinsicElements {
-      // геометрии/материалы/свет/меши, которые есть в нашем Hero3DCanvas
-      mesh: any;
-      sphereGeometry: any;
-      torusGeometry: any;
-      meshStandardMaterial: any;
-      ambientLight: any;
-      pointLight: any;
-      // если когда-то вернётся <group/>, он уже перекрыт в другом d.ts
-    }
+    interface IntrinsicElements extends ThreeElements {}
   }
 }
 
-export {};
+export {}

--- a/src/types/r3f-jsx.d.ts
+++ b/src/types/r3f-jsx.d.ts
@@ -1,11 +1,9 @@
-import '@react-three/fiber';
+import type { ThreeElements } from '@react-three/fiber'
 
-// Локальная декларация на случай, если окружение не подхватило типы R3F
 declare global {
   namespace JSX {
-    interface IntrinsicElements {
-      group: any;
-    }
+    interface IntrinsicElements extends ThreeElements {}
   }
 }
-export {};
+
+export {}

--- a/src/types/react-three-fiber.d.ts
+++ b/src/types/react-three-fiber.d.ts
@@ -6,4 +6,10 @@ declare global {
   }
 }
 
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends ThreeElements {}
+  }
+}
+
 export {}


### PR DESCRIPTION
## Summary
- remove the ts-nocheck pragma from the hero canvas and adopt typed constants/refs based on @react-three/fiber
- replace the custom intrinsic element shims with declarations that extend ThreeElements and add a shared declaration file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceab2349cc832a9908495609ae484d