### PR TITLE
Add SEO metadata to home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head'
 import dynamic from 'next/dynamic'
 import HeroOverlay from '@/components/HeroOverlay'
 
@@ -17,37 +18,61 @@ const Hero3DCanvas = dynamic(() => import('@/components/Hero3DCanvas'), {
 
 export default function Home() {
   return (
-    <main style={{ minHeight: '100vh', background: '#0b1220', color: '#fff' }}>
-      <section
-        style={{
-          position: 'relative',
-          overflow: 'hidden',
-          minHeight: '520px',
-        }}
-      >
-        {/* 3D-канвас под текстом */}
-        <div style={{ position: 'absolute', inset: 0 }}>
-          <Hero3DCanvas />
-        </div>
-
-        {/* DOM-оверлей с H1/подзаголовком/CTA */}
-        <HeroOverlay />
-
-        {/* Мягкая подложка снизу для читаемости */}
-        <div
-          style={{
-            pointerEvents: 'none',
-            position: 'absolute',
-            left: 0,
-            right: 0,
-            bottom: 0,
-            height: '160px',
-            background: 'linear-gradient(0deg, #0b1220, rgba(11,18,32,0))',
-          }}
+    <>
+      <Head>
+        <title>GTC — AI Purchasing Assistant for Smarter Procurement</title>
+        <meta
+          name="description"
+          content="GTC is your AI-powered purchasing assistant that automates procurement research, vendor comparisons, and decision-making insights."
         />
-      </section>
+        <meta property="og:title" content="GTC — AI Purchasing Assistant" />
+        <meta
+          property="og:description"
+          content="Automate procurement research, compare vendors, and uncover insights with GTC's AI purchasing assistant."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content="/fallback-hero.png" />
+        <meta property="og:url" content="https://gtc.ai" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="GTC — AI Purchasing Assistant" />
+        <meta
+          name="twitter:description"
+          content="Streamline procurement workflows with GTC's intelligent AI assistant for purchasing teams."
+        />
+        <meta name="twitter:image" content="/fallback-hero.png" />
+      </Head>
+      <main style={{ minHeight: '100vh', background: '#0b1220', color: '#fff' }}>
+        <section
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            minHeight: '520px',
+          }}
+        >
+          {/* 3D-канвас под текстом */}
+          <div style={{ position: 'absolute', inset: 0 }}>
+            <Hero3DCanvas />
+          </div>
 
-      {/* Ниже можете разместить статический контент секций */}
-    </main>
+          {/* DOM-оверлей с H1/подзаголовком/CTA */}
+          <HeroOverlay />
+
+          {/* Мягкая подложка снизу для читаемости */}
+          <div
+            style={{
+              pointerEvents: 'none',
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: '160px',
+              background: 'linear-gradient(0deg, #0b1220, rgba(11,18,32,0))',
+            }}
+          />
+        </section>
+
+        {/* Ниже можете разместить статический контент секций */}
+      </main>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add a Head section to the home page with SEO metadata for the AI purchasing assistant
- reference the existing hero fallback image for Open Graph and Twitter previews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01c042d60832aba7d5e4ce38c242f