### PR TITLE
feat: restyle hero overlay layout

### DIFF
--- a/src/components/HeroOverlay.tsx
+++ b/src/components/HeroOverlay.tsx
@@ -3,39 +3,44 @@ const buttonBase =
 
 export default function HeroOverlay() {
   return (
-    <div className="relative z-10 mx-auto max-w-[960px] px-6 py-16 text-center text-white md:px-8">
+    <div className="relative z-10 mx-auto flex max-w-[960px] flex-col px-6 pb-20 pt-16 text-center text-white md:px-8">
       <h1 className="text-4xl font-semibold leading-tight tracking-tight text-white md:text-5xl">
-        AI platform for smarter purchasing decisions
+        <span className="block">Smarter</span>
+        <span className="block">buys,</span>
+        <span className="block">happier</span>
+        <span className="block">life —</span>
+        <span className="block pl-6 md:pl-8">thanks to AI</span>
       </h1>
-      <p className="mt-4 text-lg text-white/80">
-        Make informed choices with our AI advisor, curated news, and seamless payment integration.
-      </p>
 
-      <div className="mt-7 flex flex-wrap justify-center gap-3">
-        <a
-          href="https://t.me/Procurement_AnalystBot"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`${buttonBase} bg-cyan-300 text-[#0b1220] hover:brightness-110 focus-visible:outline-cyan-200`}
-        >
-          Launch AI assistant
-        </a>
-        <a
-          href="https://app.gtstor.com/news/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`${buttonBase} bg-white/15 text-white hover:bg-white/25 focus-visible:outline-white/40`}
-        >
-          Read the news
-        </a>
-        <a
-          href="https://pay.gtstor.com/payment.php"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`${buttonBase} bg-emerald-400 text-[#0b1220] hover:brightness-110 focus-visible:outline-emerald-200`}
-        >
-          Get access
-        </a>
+      <div className="mt-14 flex justify-center">
+        <div className="relative flex h-48 w-48 items-center justify-center md:h-56 md:w-56">
+          <div className="absolute inset-0 rounded-full border border-white/40" aria-hidden />
+
+          <a
+            href="https://t.me/Procurement_AnalystBot"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${buttonBase} absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 bg-cyan-300 text-[#0b1220] hover:brightness-110 focus-visible:outline-cyan-200`}
+          >
+            AI advisor
+          </a>
+          <a
+            href="https://app.gtstor.com/news/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${buttonBase} absolute -bottom-2 left-0 -translate-y-1/2 bg-white/15 text-white hover:bg-white/25 focus-visible:outline-white/40 md:-bottom-4 md:left-2`}
+          >
+            News
+          </a>
+          <a
+            href="https://pay.gtstor.com/payment.php"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${buttonBase} absolute -bottom-2 right-0 -translate-y-1/2 bg-emerald-400 text-[#0b1220] hover:brightness-110 focus-visible:outline-emerald-200 md:-bottom-4 md:right-2`}
+          >
+            Subscribe
+          </a>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- restructure the hero heading to stack each word vertically per the new copy
- arrange the hero menu buttons in a circular layout near the bottom of the overlay

## Testing
- npm run build
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68da4e863240832aaccefa0deaca4d67