### PR TITLE
Update Get access CTA to new auth URL

### DIFF
--- a/src/components/HeroOverlay.tsx
+++ b/src/components/HeroOverlay.tsx
@@ -26,7 +26,7 @@ export default function HeroOverlay() {
           Read the news
         </a>
         <a
-          href="https://pay.gtstor.com/payment.php"
+          href="https://app.gtstor.com/auth/"
           target="_blank"
           rel="noopener noreferrer"
           className={`${buttonBase} bg-emerald-400 text-[#0b1220] hover:brightness-110 focus-visible:outline-emerald-200`}


### PR DESCRIPTION
## Summary
- update the Get access button in HeroOverlay to point to the new auth URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb5628b60832a9477c32920517507