### PR TITLE
Add Customer Portal link to homepage header

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,6 +36,16 @@ export default function Home() {
         <meta name="twitter:image" content="/fallback-hero.png" />
       </Head>
       <main className="min-h-screen bg-[#0b1220] text-white">
+        <div className="flex justify-end px-6 py-4 md:px-8">
+          <a
+            href="https://billing.stripe.com/p/login/9B6cN60BK1xN5A4cs0dwc00"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-semibold text-white transition hover:text-white/80"
+          >
+            Customer Portal
+          </a>
+        </div>
         <section className="relative min-h-[520px] overflow-hidden">
           {/* 3D-канвас под текстом */}
           <div className="absolute inset-0">


### PR DESCRIPTION
## Summary
- add a top-right Customer Portal link on the homepage that routes to the Stripe billing portal
- style the link with white text and hover transition while opening in a new tab

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e4f2816d98832ab8a93f6d8130720c